### PR TITLE
Change associated constants from public to internal

### DIFF
--- a/bitfields_impl/src/lib.rs
+++ b/bitfields_impl/src/lib.rs
@@ -1447,7 +1447,7 @@ fn generate_functions(
             !ignored_fields.is_empty(),
         )
     });
-    let field_consts_tokens = generate_field_constants_tokens(struct_tokens.vis.clone(), fields);
+    let field_consts_tokens = generate_field_constants_tokens(Visibility::Inherited, fields);
     let field_getters_tokens = generate_field_getters_functions_tokens(
         struct_tokens.vis.clone(),
         bitfield_attribute,


### PR DESCRIPTION
Thanks for putting together an awesome crate :)

This is a breaking change, but as the public interface is somewhat exhaustive this seems like a reasonable implementation detail to hide.

Closes #14 