### PR TITLE
Fix overflow in `from_bits`.

### DIFF
--- a/bitfields/tests/lib_tests.rs
+++ b/bitfields/tests/lib_tests.rs
@@ -1742,6 +1742,28 @@ mod tests {
     }
 
     #[test]
+    fn bitfield_full_field_size_u32() {
+        #[bitfield(u32)]
+        pub struct Bitfield {
+            data: u32,
+        }
+
+        let bitfield = Bitfield::from_bits(0xaabbccdd);
+        assert_eq!(bitfield.data(), 0xaabbccdd);
+    }
+
+    #[test]
+    fn bitfield_full_field_size_u64() {
+        #[bitfield(u64)]
+        pub struct Bitfield {
+            data: u64,
+        }
+
+        let bitfield = Bitfield::from_bits(0x11223344aabbccdd);
+        assert_eq!(bitfield.data(), 0x11223344aabbccdd);
+    }
+
+    #[test]
     fn bitfield_set_bit() {
         #[bitfield(u8, bit_ops = true)]
         #[derive(Copy, Clone)]

--- a/bitfields_impl/src/generation/bit_operations.rs
+++ b/bitfields_impl/src/generation/bit_operations.rs
@@ -20,8 +20,8 @@ pub(crate) fn generate_get_bit_tokens(
         .iter()
         .filter(|field| !does_field_have_getter(field) && !field.padding)
         .map(|field| {
-            let field_offset = field.offset as usize;
             let field_bits = field.bits as usize;
+            let field_offset = field.offset as usize;
             let field_end_bits = field_offset + field_bits;
             quote! {
                 if index >= #field_offset && index < #field_end_bits {
@@ -34,8 +34,8 @@ pub(crate) fn generate_get_bit_tokens(
         .iter()
         .filter(|field| !does_field_have_getter(field) && !field.padding)
         .map(|field| {
-            let field_offset = field.offset as usize;
             let field_bits = field.bits as usize;
+            let field_offset = field.offset as usize;
             let field_end_bits = field_offset + field_bits;
             quote! {
                 if index >= #field_offset && index < #field_end_bits {
@@ -87,8 +87,8 @@ pub(crate) fn generate_set_bit_tokens(
 
     let no_op_for_non_writable_fields =
         fields.iter().filter(|field| !does_field_have_setter(field)).map(|field| {
-            let field_offset = field.offset as usize;
             let field_bits = field.bits as usize;
+            let field_offset = field.offset as usize;
             let field_end_bits = field_offset + field_bits;
             quote! {
                 if index >= #field_offset && index < #field_end_bits {
@@ -99,8 +99,8 @@ pub(crate) fn generate_set_bit_tokens(
 
     let error_return_for_non_writable_fields =
         fields.iter().filter(|field| !does_field_have_setter(field)).map(|field| {
-            let field_offset = field.offset as usize;
             let field_bits = field.bits as usize;
+            let field_offset = field.offset as usize;
             let field_end_bits = field_offset + field_bits;
             quote! {
                 if index >= #field_offset && index < #field_end_bits {

--- a/bitfields_impl/src/generation/common.rs
+++ b/bitfields_impl/src/generation/common.rs
@@ -211,7 +211,7 @@ pub(crate) fn generate_setting_fields_from_bits_tokens(
                 }
 
                 let extract_value_bits = quote! {
-                    let mask = ((1 << #const_reference_tokens::#field_bits_const_ident) - 1) as #bitfield_type;
+                    let mask = #bitfield_type::MAX >> (#bitfield_type::BITS - #const_reference_tokens::#field_bits_const_ident);
                     let value = (bits >> #const_reference_tokens::#field_offset_const_ident) & mask;
                 };
                 if field.field_type == FieldType::CustomFieldType {
@@ -244,10 +244,10 @@ pub(crate) fn generate_setting_fields_from_bits_tokens(
                 );
             }
 
-            let field_bits = field.bits;
-            let field_offset = field.offset;
+            let field_bits = field.bits as u32;
+            let field_offset = field.offset as u32;
             let extract_value_bits = quote! {
-                let mask = ((1 << #field_bits) - 1) as #bitfield_type;
+                let mask = #bitfield_type::MAX >> (#bitfield_type::BITS - #field_bits);
                 let value = (bits >> #field_offset) & mask;
             };
 

--- a/bitfields_impl/src/generation/debug_impl.rs
+++ b/bitfields_impl/src/generation/debug_impl.rs
@@ -28,12 +28,12 @@ pub(crate) fn generate_debug_implementation(
 
     fields_msb_to_lsb.iter().for_each(|field| {
         let field_name = &field.name;
-        let field_bits = field.bits as usize;
-        let field_offset = field.offset as usize;
+        let field_bits = field.bits as u32;
+        let field_offset = field.offset as u32;
         let bitfield_type = &bitfield_attribute.ty;
 
         debug_impl.push(quote! {
-            let mask = #bitfield_type::MAX >> (#bitfield_type::BITS - #field_bits as u32);
+            let mask = #bitfield_type::MAX >> (#bitfield_type::BITS - #field_bits);
             let this = ((#struct_val_ident >> #field_offset) & mask) as #bitfield_type;
             debug.field(stringify!(#field_name), &((#struct_val_ident >> #field_offset) & mask));
         });


### PR DESCRIPTION
Fixes https://github.com/gregorygaines/bitfields-rs/issues/26.

Also changes the `*_BITS` constants to `u32`, since they are mostly used for calculations with primitive `*::BITS`.