### PR TITLE
fix: Use fully qualified ::core::result::Result

### DIFF
--- a/bitfields_impl/src/generation/bit_operations.rs
+++ b/bitfields_impl/src/generation/bit_operations.rs
@@ -63,7 +63,7 @@ pub(crate) fn generate_get_bit_tokens(
         }
 
         #[doc = #checked_get_bit_documentation]
-        #vis const fn checked_get_bit(&self, index: usize) -> Result<bool, &'static str> {
+        #vis const fn checked_get_bit(&self, index: usize) -> ::core::result::Result<bool, &'static str> {
             if index > #bitfield_type_bits {
                 return Err("Index out of bounds.");
             }
@@ -132,7 +132,7 @@ pub(crate) fn generate_set_bit_tokens(
         }
 
         #[doc = #checked_set_bit_documentation]
-        #vis const fn checked_set_bit(&mut self, index: usize, bit: bool) -> Result<(), &'static str> {
+        #vis const fn checked_set_bit(&mut self, index: usize, bit: bool) -> ::core::result::Result<(), &'static str> {
             if index > #bitfield_type_bits {
                 return Err("Index out of bounds.");
             }

--- a/bitfields_impl/src/generation/builder_struct.rs
+++ b/bitfields_impl/src/generation/builder_struct.rs
@@ -53,7 +53,7 @@ pub(crate) fn generate_builder_tokens(
                     }
 
                     #[doc = #checked_with_field_documentation]
-                    #vis fn #checked_field_name_with_builder_setter_ident(mut self, bits: #field_type) -> Result<Self, &'static str> {
+                    #vis fn #checked_field_name_with_builder_setter_ident(mut self, bits: #field_type) -> ::core::result::Result<Self, &'static str> {
                         self.this.#checked_field_offset_setter_ident(bits)?;
                         Ok(self)
                     }
@@ -85,7 +85,7 @@ pub(crate) fn generate_builder_tokens(
                     }
 
                     #[doc = #checked_with_field_documentation]
-                    #vis fn #checked_field_name_with_builder_setter_ident(mut self, bits: #field_type) -> Result<Self, &'static str> {
+                    #vis fn #checked_field_name_with_builder_setter_ident(mut self, bits: #field_type) -> ::core::result::Result<Self, &'static str> {
                         #checked_setter_impl_tokens
                         Ok(self)
                     }

--- a/bitfields_impl/src/generation/field_const_getter_setter.rs
+++ b/bitfields_impl/src/generation/field_const_getter_setter.rs
@@ -243,7 +243,7 @@ pub(crate) fn generate_field_setters_functions_tokens(
             }
 
             #[doc = #checked_setter_documentation]
-            #vis const fn #checked_field_offset_setter_ident(&mut self, bits: #field_type) -> Result<(), &'static str> {
+            #vis const fn #checked_field_offset_setter_ident(&mut self, bits: #field_type) -> ::core::result::Result<(), &'static str> {
                 let this = self;
                 #setter_with_size_check_impl_tokens
             }


### PR DESCRIPTION
Updated fn signatures to use `::core::result::Result` instead of `Result`. This change improves portability and avoids potential naming conflicts.

Especially, without this change, the following example cannot compile,

```
use std::io::Result;

use bitfields::bitfield;

#[bitfield(u8)]
struct DisplayControl {
    // ......
}
```

since `std::io::Result` only accepts 1 type parameter.

```
pub type Result<T> = Result<T, Error>;
```
https://doc.rust-lang.org/stable/std/io/type.Result.html