### PR TITLE
Fix no_std support for `Copy` bitflag and others

### DIFF
--- a/bitfields_impl/src/generating/bitfield/features/bitfield_struct_feature.rs
+++ b/bitfields_impl/src/generating/bitfield/features/bitfield_struct_feature.rs
@@ -106,7 +106,7 @@ impl BitfieldStructFeatureGenerator {
     fn get_backing_field_type_tokens(bitfield: &Bitfield) -> TokenStream {
         let inner = bitfield.spanned_data_type_token().to_tokens();
         if bitfield.arguments().array_heap() && !bitfield.is_integer_backed() {
-            quote! { ::alloc::boxed::Box<#inner> }
+            quote! { ::std::boxed::Box<#inner> }
         } else {
             inner
         }

--- a/bitfields_impl/src/generating/bitfield/features/bitfield_struct_feature.rs
+++ b/bitfields_impl/src/generating/bitfield/features/bitfield_struct_feature.rs
@@ -87,7 +87,7 @@ impl BitfieldStructFeatureGenerator {
                 });
             } else {
                 attributes_tokens.push(quote! {
-                    #[derive(std::marker::Copy, core::clone::Clone)]
+                    #[derive(core::marker::Copy, core::clone::Clone)]
                 });
             }
         }
@@ -106,7 +106,7 @@ impl BitfieldStructFeatureGenerator {
     fn get_backing_field_type_tokens(bitfield: &Bitfield) -> TokenStream {
         let inner = bitfield.spanned_data_type_token().to_tokens();
         if bitfield.arguments().array_heap() && !bitfield.is_integer_backed() {
-            quote! { ::std::boxed::Box<#inner> }
+            quote! { ::alloc::boxed::Box<#inner> }
         } else {
             inner
         }

--- a/bitfields_impl/src/generating/bitfield/features/common/generator_helper.rs
+++ b/bitfields_impl/src/generating/bitfield/features/common/generator_helper.rs
@@ -57,7 +57,7 @@ pub fn generate_bitfield_struct_initialization_tokens(
             let length = length as usize;
             if bitfield.arguments().array_heap() {
                 quote! {
-                    ::alloc::boxed::Box::new([0u8; #length])
+                    ::std::boxed::Box::new([0u8; #length])
                 }
             } else {
                 quote! {

--- a/bitfields_impl/src/generating/bitfield/features/common/generator_helper.rs
+++ b/bitfields_impl/src/generating/bitfield/features/common/generator_helper.rs
@@ -57,7 +57,7 @@ pub fn generate_bitfield_struct_initialization_tokens(
             let length = length as usize;
             if bitfield.arguments().array_heap() {
                 quote! {
-                    ::std::boxed::Box::new([0u8; #length])
+                    ::alloc::boxed::Box::new([0u8; #length])
                 }
             } else {
                 quote! {

--- a/bitfields_impl/src/generating/bitflag/bitflag_generator.rs
+++ b/bitfields_impl/src/generating/bitflag/bitflag_generator.rs
@@ -40,7 +40,7 @@ fn generate_repr_tokens(bitflag: &Bitflag) -> TokenStream {
 fn generate_copy_derive_tokens(bitflag: &Bitflag) -> TokenStream {
     if bitflag.arguments().derive_copy() {
         quote! {
-            #[derive(std::marker::Copy, core::clone::Clone)]
+            #[derive(core::marker::Copy, core::clone::Clone)]
         }
     } else {
         quote! {}


### PR DESCRIPTION
The current version of `#[bitflag]` emits `#[derive(std::marker::Copy, core::clone::Clone)]` which will fail if building from `no_std`. I've changed this and a few other instances of `std` references to `core` and `alloc` so that the macros will work on `no_std`.

The `Cargo.toml` currently pins a specific nightly version (`1.95`) which has been released now. Should that be changed?